### PR TITLE
badges, license, declared python 3.6 support, Travis, Codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+branch = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: python
+sudo: true
+branches:
+    only:
+        - master
+        - /^\d\.\d+$/
+
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: pypy
+      env: TOXENV=pypy
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+
+install:
+    - pip install -U pip tox codecov
+
+script: tox
+
+after_success:
+    - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: true
 branches:
     only:
         - master

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) json-lines developers.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,18 @@
 json-lines
 ==========
 
+.. image:: https://img.shields.io/pypi/v/json-lines.svg
+   :target: https://pypi.python.org/pypi/json-lines
+   :alt: PyPI Version
+
+.. image:: https://travis-ci.org/TeamHG-Memex/json-lines.svg?branch=master
+   :target: http://travis-ci.org/TeamHG-Memex/json-lines
+   :alt: Build Status
+
+.. image:: http://codecov.io/github/TeamHG-Memex/json-lines/coverage.svg?branch=master
+   :target: http://codecov.io/github/TeamHG-Memex/json-lines?branch=master
+   :alt: Code Coverage
+
 This is a tiny library for reading JSON lines (.jl) files,
 including gzipped and broken files.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+comment:
+  layout: "header, diff, tree"
+
+coverage:
+  status:
+    project: false

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,12 @@ def read(fname):
 
 
 setup(
-    name = 'json-lines',
-    version = '0.2.0',
-    description = 'Reading JSON lines (jl) files',
-    license = 'MIT',
-    url = 'https://github.com/TeamHG-Memex/json-lines',
-    packages = ['json_lines'],
+    name='json-lines',
+    version='0.2.0',
+    description='Reading JSON lines (jl) files',
+    license='MIT',
+    url='https://github.com/TeamHG-Memex/json-lines',
+    packages=['json_lines'],
     long_description=read('README.rst'),
     install_requires=[
         'six',
@@ -24,8 +24,8 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 ; under all supported Python interpreters
 
 [tox]
-envlist = py27,pypy,py35
+envlist = py27,pypy,py34,py35,py36
 
 [testenv]
 deps=


### PR DESCRIPTION
This pull request adds fancy badges, CI support and a license file. 

I removed Python 3.3 from a list of tested/supported versions because it is rarely used; json-lines will likely still work for it for a long time.