### PR TITLE
[MRG] handle multiple concatenated broken archives

### DIFF
--- a/json_lines/_gzip.py
+++ b/json_lines/_gzip.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+import io
+import gzip
+import mmap
+from contextlib import closing
+
+GZIP_SIGNATURE = b'\x1f\x8b\x08'
+
+
+def get_known_read_position(fp, buffered=True):
+    """ 
+    Return a position in a file which is known to be read & handled.
+    It assumes a buffered file and streaming processing. 
+    """
+    buffer_size = io.DEFAULT_BUFFER_SIZE if buffered else 0
+    return max(fp.tell() - buffer_size, 0)
+
+
+def recover(gzfile, last_good_position):
+    # type: (gzip.GzipFile, int) -> gzip.GzipFile
+    """ 
+    Skip to the next possibly decompressable part of a gzip file.
+    Return a new GzipFile object if such part is found or None
+    if it is not found.
+    """
+    pos = get_recover_position(gzfile, last_good_position=last_good_position)
+    if pos == -1:
+        return None
+    fp = gzfile.fileobj
+    fp.seek(pos)
+#     gzfile.close()
+    return gzip.GzipFile(fileobj=fp, mode='r')
+
+
+def get_recover_position(gzfile, last_good_position):
+    # type: (gzip.GzipFile, int) -> int
+    """
+    Return position of a next gzip stream in a GzipFile, 
+    or -1 if it is not found.
+    
+    XXX: caller must ensure that the same last_good_position
+    is not used multiple times for the same gzfile.
+    """
+    with closing(mmap.mmap(gzfile.fileno(), 0, access=mmap.ACCESS_READ)) as m:
+        return m.find(GZIP_SIGNATURE, last_good_position + 1)

--- a/json_lines/_lib.py
+++ b/json_lines/_lib.py
@@ -1,9 +1,11 @@
+from __future__ import absolute_import
 from contextlib import contextmanager
-import gzip
 import json
+import gzip
 import logging
-
 import six
+
+from ._gzip import recover, get_known_read_position
 
 
 __all__ = ['open_file', 'reader', 'open']
@@ -34,21 +36,80 @@ def reader(file, broken=False):
     Read .jl or .jl.gz file with JSON lines data,
     return iterator with decoded lines.
     If the .jl.gz archive is broken as much lines as possible are read from
-    the archive, and then an error is logged.
+    the archive.
     """
-    try:
-        for line in file:
+    if not broken:
+        return _iter_json_lines(file)
+    else:
+        return _iter_json_lines_recovering(file)
+
+
+def _iter_json_lines(file):
+    return (_decode_json_line(line) for line in file)
+
+
+def _decode_json_line(line):
+    if not isinstance(line, six.text_type):
+        line = line.decode('utf8')
+    return json.loads(line)
+
+
+def _iter_json_lines_recovering(file):
+    is_gzip = hasattr(file, 'fileobj')
+    jl_reader = _JlRecoveringReader(file,
+                                    recover_gzip=is_gzip,
+                                    recover_jl=not is_gzip)
+    while True:
+        try:
+            for line in jl_reader.iter_lines():
+                yield line
+            return
+        except Exception as e:
+            logging.warning("Error found, trying to recover from %r" % e)
+            if not jl_reader.try_gzip_recovering():
+                logging.warning("Can't recover.")
+                return
+            logging.warning('Recovery successful, starting again from %s' %
+                            jl_reader.last_good_position)
+
+
+class _JlRecoveringReader(object):
+    def __init__(self, file, recover_gzip=True, recover_jl=False):
+        self.last_good_position = 0
+        self.file = file
+        self.recover_jl = recover_jl
+        self.recover_gzip = recover_gzip
+
+    def iter_lines(self):
+        for line in self.file:
             try:
-                if not isinstance(line, six.text_type):
-                    line = line.decode('utf8')
-                yield json.loads(line)
+                yield _decode_json_line(line)
             except Exception as e:
-                if not broken:
+                if not self.recover_jl:
                     raise
-                logging.warning(
-                    'Error found: JSON line can\'t be decoded. %r' % e)
-                break
-    except Exception as e:
-        if not broken:
-            raise
-        logging.warning('Error found: truncated archive. %r' % e)
+                logging.warning("Error: JSON line can't be decoded. %r" % e)
+            else:
+                if self.recover_gzip:
+                    self._mark_good(self.file, buffered=True)
+
+    def try_gzip_recovering(self):
+        if not self.recover_gzip:
+            return False
+
+        logging.debug(
+            "Position: %s current, %s certainly handled, %s last good" % (
+                self.file.fileobj.tell(),
+                get_known_read_position(self.file.fileobj),
+                self.last_good_position,
+            )
+        )
+        self.file = recover(self.file,
+                            last_good_position=self.last_good_position)
+        if self.file is None:
+            return False
+        self._mark_good(self.file, buffered=False)
+        return True
+
+    def _mark_good(self, file, buffered):
+        self.last_good_position = get_known_read_position(file.fileobj,
+                                                          buffered)

--- a/tests.py
+++ b/tests.py
@@ -11,100 +11,100 @@ def jl_bytes(data):
     return '\n'.join(json.dumps(x) for x in data).encode('utf8')
 
 
-def test_reader_path():
-    with tempfile.NamedTemporaryFile(delete=False) as f:
-        data = [{'a': 1}, {'b': 2}]
-        f.write(jl_bytes(data))
-        f.close()
-        with json_lines.open_file(f.name) as f_:
-            assert list(json_lines.reader(f_)) == data
+def test_reader_path(tmpdir):
+    data = [{'a': 1}, {'b': 2}]
+    p = tmpdir.join('myfile.jl')
+    p.write(jl_bytes(data))
+
+    with json_lines.open_file(str(p)) as f:
+        assert list(json_lines.reader(f)) == data
 
 
-def test_reader_file():
-    with tempfile.NamedTemporaryFile(delete=False) as f:
-        data = [{'a': 1}, {'b': 2}]
-        f.write(jl_bytes(data))
-        f.close()
-        with open(f.name, 'rb') as f_:
-            assert list(json_lines.reader(f_)) == data
+def test_reader_file(tmpdir):
+    data = [{'a': 1}, {'b': 2}]
+    p = tmpdir.join('myfile.jl')
+    p.write(jl_bytes(data))
+
+    with open(str(p), 'rb') as f:
+        assert list(json_lines.reader(f)) == data
 
 
-def test_reader_gzip_file():
-    with tempfile.NamedTemporaryFile(delete=False) as f:
-        f.close()
-        data = [{'a': 1}, {'b': 2}]
-        with gzip.open(f.name, 'wb') as gzip_f:
-            gzip_f.write(jl_bytes(data))
-        with gzip.open(f.name, 'rb') as f_:
-            assert list(json_lines.reader(f_)) == data
+def test_reader_gzip_file(tmpdir):
+    data = [{'a': 1}, {'b': 2}]
+    p = tmpdir.join('myfile.jl')
+    with gzip.open(str(p), 'wb') as gzip_f:
+        gzip_f.write(jl_bytes(data))
+
+    with gzip.open(str(p), 'rb') as f:
+        assert list(json_lines.reader(f)) == data
 
 
-def test_reader_gzip_path():
-    with tempfile.NamedTemporaryFile(delete=False, suffix='.jl.gz') as f:
-        f.close()
-        data = [{'a': 1}, {'b': 2}]
-        with gzip.open(f.name, 'wb') as gzip_f:
-            gzip_f.write(jl_bytes(data))
-        with json_lines.open_file(f.name) as f_:
-            assert list(json_lines.reader(f_)) == data
+def test_reader_gzip_path(tmpdir):
+    data = [{'a': 1}, {'b': 2}]
+    p = tmpdir.join('myfile.jl.gz')
+    with gzip.open(str(p), 'wb') as gzip_f:
+        gzip_f.write(jl_bytes(data))
+
+    with json_lines.open_file(str(p)) as f_:
+        assert list(json_lines.reader(f_)) == data
 
 
-def test_reader_broken_fail():
-    with tempfile.NamedTemporaryFile(delete=False, suffix='.jl.gz') as f:
-        f.close()
-        with open(f.name, 'wb') as f_:
-            f_.write(b'somedata')
-        with json_lines.open_file(f.name) as f_:
-            with pytest.raises(Exception):
-                _ = list(json_lines.reader(f_))
+def test_reader_broken_fail(tmpdir):
+    p = tmpdir.join('myfile.jl.gz')
+    p.write(b'somedata')
+
+    with json_lines.open_file(str(p)) as f_:
+        with pytest.raises(Exception):
+            _ = list(json_lines.reader(f_))
 
 
-def test_reader_broken_json_fail():
-    with tempfile.NamedTemporaryFile(delete=False, suffix='.jl.gz') as f:
-        f.close()
-        with gzip.open(f.name, 'wb') as gzip_f:
-            gzip_f.write(b'{"a": 1}\n{[]')
-        with json_lines.open_file(f.name) as f_:
-            with pytest.raises(Exception):
-                _ = list(json_lines.reader(f_))
+def test_reader_broken_json_fail(tmpdir):
+    p = tmpdir.join('myfile.jl.gz')
+    with gzip.open(str(p), 'wb') as gzip_f:
+        gzip_f.write(b'{"a": 1}\n{[]')
+
+    with json_lines.open_file(str(p)) as f_:
+        with pytest.raises(Exception):
+            _ = list(json_lines.reader(f_))
 
 
-def test_reader_broken():
-    with tempfile.NamedTemporaryFile(delete=False, suffix='.jl.gz') as f:
-        f.close()
-        data = [{'a': 1}]
-        with gzip.open(f.name, 'wb') as gzip_f:
-            gzip_f.write(jl_bytes(data * 1000))
-        with open(f.name, 'rb') as f_:
-            contents = f_.read()
-        with open(f.name, 'wb') as f_:
-            f_.write(contents[:-10])
-        with json_lines.open_file(f.name) as f_:
+def test_reader_broken(tmpdir):
+    p = tmpdir.join('myfile.jl.gz')
+    data = [{'a': 1}]
+    with gzip.open(str(p), 'wb') as gzip_f:
+        gzip_f.write(jl_bytes(data * 1000))
+    with open(str(p), 'rb') as f_:
+        contents = f_.read()
+    with open(str(p), 'wb') as f_:
+        f_.write(contents[:-10])
+
+    with json_lines.open_file(str(p)) as f_:
+        read_data = list(json_lines.reader(f_, broken=True))
+        assert read_data[:900] == data * 900
+
+
+def test_reader_broken_json(tmpdir):
+    p = tmpdir.join('myfile.jl.gz')
+    with gzip.open(str(p), 'wb') as gzip_f:
+        gzip_f.write(b'{"a": 1}\n{[]')
+
+    with json_lines.open_file(str(p)) as f_:
+        read_data = list(json_lines.reader(f_, broken=True))
+        assert read_data == [{'a': 1}]
+
+
+def test_reader_broken_fuzz(tmpdir):
+    p = tmpdir.join('myfile.jl.gz')
+    data = [{'a': 1}]
+    with gzip.open(str(p), 'wb') as gzip_f:
+        gzip_f.write(jl_bytes(data * 1000))
+
+    with open(str(p), 'rb') as f_:
+        contents = f_.read()
+    for cut in range(1, min(1000, len(contents))):
+        with open(str(p), 'wb') as f_:
+            f_.write(contents[:-cut])
+        with json_lines.open_file(str(p)) as f_:
             read_data = list(json_lines.reader(f_, broken=True))
-            assert read_data[:900] == data * 900
+            assert isinstance(read_data, list)
 
-
-def test_reader_broken_json():
-    with tempfile.NamedTemporaryFile(delete=False, suffix='.jl.gz') as f:
-        f.close()
-        with gzip.open(f.name, 'wb') as gzip_f:
-            gzip_f.write(b'{"a": 1}\n{[]')
-        with json_lines.open_file(f.name) as f_:
-            read_data = list(json_lines.reader(f_, broken=True))
-            assert read_data == [{'a': 1}]
-
-
-def test_reader_broken_fuzz():
-    with tempfile.NamedTemporaryFile(delete=False, suffix='.jl.gz') as f:
-        f.close()
-        data = [{'a': 1}]
-        with gzip.open(f.name, 'wb') as gzip_f:
-            gzip_f.write(jl_bytes(data * 1000))
-        with open(f.name, 'rb') as f_:
-            contents = f_.read()
-        for cut in range(1, min(1000, len(contents))):
-            with open(f.name, 'wb') as f_:
-                f_.write(contents[:-cut])
-            with json_lines.open_file(f.name) as f_:
-                read_data = list(json_lines.reader(f_, broken=True))
-                assert isinstance(read_data, list)

--- a/tests.py
+++ b/tests.py
@@ -18,7 +18,7 @@ def write_jl_gz(path, data, mode='wb'):
 def test_reader_path(tmpdir):
     data = [{'a': 1}, {'b': 2}]
     p = tmpdir.join('myfile.jl')
-    p.write(jl_bytes(data))
+    p.write_binary(jl_bytes(data))
 
     with json_lines.open_file(str(p)) as f:
         assert list(json_lines.reader(f)) == data
@@ -27,7 +27,7 @@ def test_reader_path(tmpdir):
 def test_reader_file(tmpdir):
     data = [{'a': 1}, {'b': 2}]
     p = tmpdir.join('myfile.jl')
-    p.write(jl_bytes(data))
+    p.write_binary(jl_bytes(data))
 
     with open(str(p), 'rb') as f:
         assert list(json_lines.reader(f)) == data
@@ -53,7 +53,7 @@ def test_reader_gzip_path(tmpdir):
 
 def test_reader_broken_fail(tmpdir):
     p = tmpdir.join('myfile.jl.gz')
-    p.write(b'somedata')
+    p.write('somedata')
 
     with json_lines.open_file(str(p)) as f_:
         with pytest.raises(Exception):
@@ -74,10 +74,7 @@ def test_reader_broken(tmpdir):
     p = tmpdir.join('myfile.jl.gz')
     data = [{'a': 1}]
     write_jl_gz(p, data * 1000)
-    with open(str(p), 'rb') as f_:
-        contents = f_.read()
-    with open(str(p), 'wb') as f_:
-        f_.write(contents[:-10])
+    p.write_binary(p.read_binary()[:-10])
 
     with json_lines.open_file(str(p)) as f_:
         read_data = list(json_lines.reader(f_, broken=True))
@@ -98,12 +95,10 @@ def test_reader_broken_fuzz(tmpdir):
     p = tmpdir.join('myfile.jl.gz')
     data = [{'a': 1}]
     write_jl_gz(p, data * 1000)
+    contents = p.read_binary()
 
-    with open(str(p), 'rb') as f_:
-        contents = f_.read()
     for cut in range(1, min(1000, len(contents))):
-        with open(str(p), 'wb') as f_:
-            f_.write(contents[:-cut])
+        p.write_binary(contents[:-cut])
         with json_lines.open_file(str(p)) as f_:
             read_data = list(json_lines.reader(f_, broken=True))
             assert isinstance(read_data, list)

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,5 @@
 import gzip
 import json
-import tempfile
 
 import pytest
 
@@ -9,6 +8,11 @@ import json_lines
 
 def jl_bytes(data):
     return '\n'.join(json.dumps(x) for x in data).encode('utf8')
+
+
+def write_jl_gz(path, data, mode='wb'):
+    with gzip.open(str(path), mode) as f:
+        f.write(jl_bytes(data))
 
 
 def test_reader_path(tmpdir):
@@ -32,8 +36,7 @@ def test_reader_file(tmpdir):
 def test_reader_gzip_file(tmpdir):
     data = [{'a': 1}, {'b': 2}]
     p = tmpdir.join('myfile.jl')
-    with gzip.open(str(p), 'wb') as gzip_f:
-        gzip_f.write(jl_bytes(data))
+    write_jl_gz(p, data)
 
     with gzip.open(str(p), 'rb') as f:
         assert list(json_lines.reader(f)) == data
@@ -42,8 +45,7 @@ def test_reader_gzip_file(tmpdir):
 def test_reader_gzip_path(tmpdir):
     data = [{'a': 1}, {'b': 2}]
     p = tmpdir.join('myfile.jl.gz')
-    with gzip.open(str(p), 'wb') as gzip_f:
-        gzip_f.write(jl_bytes(data))
+    write_jl_gz(p, data)
 
     with json_lines.open_file(str(p)) as f_:
         assert list(json_lines.reader(f_)) == data
@@ -71,8 +73,7 @@ def test_reader_broken_json_fail(tmpdir):
 def test_reader_broken(tmpdir):
     p = tmpdir.join('myfile.jl.gz')
     data = [{'a': 1}]
-    with gzip.open(str(p), 'wb') as gzip_f:
-        gzip_f.write(jl_bytes(data * 1000))
+    write_jl_gz(p, data * 1000)
     with open(str(p), 'rb') as f_:
         contents = f_.read()
     with open(str(p), 'wb') as f_:
@@ -96,8 +97,7 @@ def test_reader_broken_json(tmpdir):
 def test_reader_broken_fuzz(tmpdir):
     p = tmpdir.join('myfile.jl.gz')
     data = [{'a': 1}]
-    with gzip.open(str(p), 'wb') as gzip_f:
-        gzip_f.write(jl_bytes(data * 1000))
+    write_jl_gz(p, data * 1000)
 
     with open(str(p), 'rb') as f_:
         contents = f_.read()

--- a/tests.py
+++ b/tests.py
@@ -1,18 +1,23 @@
 import gzip
 import json
+import random
 
 import pytest
 
 import json_lines
 
 
-def jl_bytes(data):
-    return '\n'.join(json.dumps(x) for x in data).encode('utf8')
+def write_gz(path, data, mode='wb'):
+    with gzip.open(str(path), mode) as f:
+        f.write(data)
 
 
 def write_jl_gz(path, data, mode='wb'):
-    with gzip.open(str(path), mode) as f:
-        f.write(jl_bytes(data))
+    write_gz(path, data=jl_bytes(data), mode=mode)
+
+
+def jl_bytes(data):
+    return '\n'.join(json.dumps(x) for x in data).encode('utf8')
 
 
 def test_reader_path(tmpdir):
@@ -53,7 +58,7 @@ def test_reader_gzip_path(tmpdir):
 
 def test_reader_broken_fail(tmpdir):
     p = tmpdir.join('myfile.jl.gz')
-    p.write('somedata')
+    p.write_binary(b'somedata')
 
     with json_lines.open_file(str(p)) as f_:
         with pytest.raises(Exception):
@@ -62,15 +67,14 @@ def test_reader_broken_fail(tmpdir):
 
 def test_reader_broken_json_fail(tmpdir):
     p = tmpdir.join('myfile.jl.gz')
-    with gzip.open(str(p), 'wb') as gzip_f:
-        gzip_f.write(b'{"a": 1}\n{[]')
+    write_gz(p, b'{"a": 1}\n{[]')
 
     with json_lines.open_file(str(p)) as f_:
         with pytest.raises(Exception):
             _ = list(json_lines.reader(f_))
 
 
-def test_reader_broken(tmpdir):
+def test_reader_broken_single(tmpdir):
     p = tmpdir.join('myfile.jl.gz')
     data = [{'a': 1}]
     write_jl_gz(p, data * 1000)
@@ -81,14 +85,47 @@ def test_reader_broken(tmpdir):
         assert read_data[:900] == data * 900
 
 
+def test_reader_broken_multiple(tmpdir):
+    p = tmpdir.join('myfile.jl.gz')
+    data_a = [{'a': random.random()} for _ in range(1000)]
+    data_b = [{'b': random.random()} for _ in range(1000)]
+
+    write_jl_gz(p, data_a)
+    p.write_binary(p.read_binary()[:-10])
+    write_jl_gz(p, data_b, 'ab')
+
+    with json_lines.open_file(str(p)) as f:
+        read_data = list(json_lines.reader(f, broken=True))
+        assert read_data[:900] == data_a[:900]  # first part is recovered
+        assert read_data[-1000:] == data_b  # second part is recovered
+
+
 def test_reader_broken_json(tmpdir):
     p = tmpdir.join('myfile.jl.gz')
-    with gzip.open(str(p), 'wb') as gzip_f:
-        gzip_f.write(b'{"a": 1}\n{[]')
+    write_gz(p, b'{"a": 1}\n{[]')
 
     with json_lines.open_file(str(p)) as f_:
         read_data = list(json_lines.reader(f_, broken=True))
         assert read_data == [{'a': 1}]
+
+
+def test_reader_broken_json_partial(tmpdir):
+    # with broken=True broken json lines are skipped, but reading continues
+    p = tmpdir.join('myfile.jl')
+    p.write_binary(b'{"a": 1}\n{"a": 2\n{"b": 1}\n')
+    with json_lines.open(str(p), broken=True) as f:
+        lines = list(f)
+    assert lines == [{'a': 1}, {'b': 1}]
+
+
+def test_reader_broken_json_partial_gzipped(tmpdir):
+    # For gzip files broken=True only means gzip recovery, inside a single
+    # archive processing stops at first broken json line
+    p = tmpdir.join('myfile.jl.gz')
+    write_gz(p, b'{"a": 1}\n{"a": 2\n{"b": 1}\n')
+    with json_lines.open(str(p), broken=True) as f:
+        lines = list(f)
+    assert lines == [{'a': 1}]
 
 
 def test_reader_broken_fuzz(tmpdir):
@@ -102,4 +139,3 @@ def test_reader_broken_fuzz(tmpdir):
         with json_lines.open_file(str(p)) as f_:
             read_data = list(json_lines.reader(f_, broken=True))
             assert isinstance(read_data, list)
-


### PR DESCRIPTION
Recovery algorithm is the following:

1. json lines are read from a gzipped fIle; 
2. after each successful line read position of a underlying file pointer is remembered. It is tricky because reading is buffered (even if file is opened without a buffer - Python's gzip has its own buffering); we remember a "conservative" estimate of a position.
3. when error happens we're starting to look for a gzip signature after last successful read position. To do so without loading the whole file in memory mmap is used. Changing file pointer of a GzipFIle is tricky, so a new GzipFile is created, which starts to read the file from a right position (i.e. from the next gzip signature).
4. after each successful restart "last good position" is also changed. It means this position can only increase or stay the same, and after "restart" position always increases; step (3) uses "last_good_position + 1", so there shouldn't be an infinite loop.



The current implementation likely doesn't work for GzipFile wrapping a BytesIO object; it needs a real file.