### PR TITLE
support pathlib.Path objects in json_lines.open

### DIFF
--- a/json_lines/_lib.py
+++ b/json_lines/_lib.py
@@ -28,6 +28,7 @@ def open_file(path, *args, **kwargs):
     """
     Open file with either open or gzip.open, depending on file extension.
     """
+    path = _path_to_str(path)
     if path.endswith('.gz') or path.endswith('.gzip'):
         _open = gzip.open
     else:
@@ -117,3 +118,15 @@ class _JlRecoveringReader(object):
     def _mark_good(self, file, buffered):
         self.last_good_position = get_known_read_position(file.fileobj,
                                                           buffered)
+
+
+def _path_to_str(path):
+    """ Convert pathlib.Path objects to str; return other objects as-is. """
+    try:
+        from pathlib import Path as _Path
+    except ImportError:  # Python < 3.4
+        class _Path:
+            pass
+    if isinstance(path, _Path):
+        return str(path)
+    return path

--- a/tests.py
+++ b/tests.py
@@ -139,3 +139,19 @@ def test_reader_broken_fuzz(tmpdir):
         with json_lines.open_file(str(p)) as f_:
             read_data = list(json_lines.reader(f_, broken=True))
             assert isinstance(read_data, list)
+
+
+def test_pathlib_open(tmpdir):
+    pathlib = pytest.importorskip("pathlib")
+    data = [{'a': 1}, {'b': 2}]
+    p = tmpdir.join('myfile.jl')
+    p.write_binary(jl_bytes(data))
+
+    with json_lines.open(pathlib.Path(str(p))) as lines:
+        assert list(lines) == data
+
+
+def test_open_wrong_type():
+    with pytest.raises(Exception):
+        with json_lines.open(123) as lines:
+            pass


### PR DESCRIPTION
currently json_lines.open fail for them, as they don't have .endswith method. 